### PR TITLE
Remove unused import of sun.jvm that breaks building in Java8

### DIFF
--- a/src/main/java/com/pragone/jphash/image/SimpleGrayscaleImage.java
+++ b/src/main/java/com/pragone/jphash/image/SimpleGrayscaleImage.java
@@ -1,6 +1,5 @@
 package com.pragone.jphash.image;
 
-import sun.jvm.hotspot.debugger.Debugger;
 import sun.misc.Cleaner;
 
 import javax.imageio.ImageIO;


### PR DESCRIPTION
Cant run `mvn package -DskipTests` on Java 8 without the removal of that unused import. Just a one-liner!